### PR TITLE
Leverage semver instead of locking to patch versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4.0",
         "psr/http-message": "1.0",
-        "willdurand/negotiation": "2.0.1"
+        "willdurand/negotiation": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",


### PR DESCRIPTION
My app is running `willdurand/negotiation` version 2.0.2 already. This library should allow other 2.x versions beyond only this one single patch release of 2.0.1.
