### PR TITLE
Add support for PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4.0",
         "psr/http-message": "^1.0",
-        "willdurand/negotiation": "^2.0|^3.0"
+        "willdurand/negotiation": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4.0",
         "psr/http-message": "^1.0",
-        "willdurand/negotiation": "^2.0"
+        "willdurand/negotiation": "^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",


### PR DESCRIPTION
This PR will allow the middleware to be installed with a PHP 8 compatible version of willdurand/negotiation thus making also the middleware itself PHP 8 compatible.